### PR TITLE
Fix value not being stored as DateTime

### DIFF
--- a/lib/datetime_picker_formfield.dart
+++ b/lib/datetime_picker_formfield.dart
@@ -287,6 +287,7 @@ class _DateTimeFieldState extends FormFieldState<DateTime> {
       final newValue = await widget.onShowPicker(context, value);
       isShowingDialog = false;
       if (newValue != null) {
+        setValue(newValue);
         _effectiveController!.text = format(newValue);
       }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: datetime_picker_formfield
+name: datetime_picker_formfield_new
 description: A TextFormField that emits DateTimes and helps show Material, Cupertino, and other style picker dialogs.
 version: 2.1.0
 homepage: https://github.com/jifalops/datetime_picker_formfield


### PR DESCRIPTION
This fixes the issue of the `newValue` not being stored as a `DateTime` after selecting it.

I was running into an issue where a user would select a date. Since this just updated the text, and I'm using a DateFormat that only shows the month and day, the year was completely lost. Now, the `newValue` is set as the field's value after being selected (if not null). So now, no matter how you format the date text, it will give you the correct `DateTime` to save.